### PR TITLE
+ Compatibilidad con EXE

### DIFF
--- a/source/mh_apache.prg
+++ b/source/mh_apache.prg
@@ -58,6 +58,7 @@ FUNCTION mh_PPRules()
          __pp_Path( hPP, hb_GetEnv( "HB_INCLUDE" ) )
       ENDIF
 
+      __pp_AddRule( hPP, "#define __MODHARBOUR__" )
       __pp_AddRule( hPP, "#xcommand ? [<explist,...>] => ap_Echo( '<br>' [,<explist>] )" )
       __pp_AddRule( hPP, "#xcommand ?? [<explist,...>] => ap_Echo( [<explist>] )" )
       __pp_AddRule( hPP, "#define CRLF hb_OsNewLine()" )


### PR DESCRIPTION
Si se necesita compatibilidad para distinguir si la ejecución viene por el mod o por exe (cgi), por ejemplo

#ifdef __MODHARBOUR__
	#include "{% hb_GetEnv('PRGPATH')+'/menu.prg'%}"
#endif

En un cgi, el modulo menu.prg ya viene compilado